### PR TITLE
Add Chartbeat "section" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ Configuration
 Usage
 -----
     hubot chart me        - Returns active concurrent visitors from the default site specified.
-    hubot chart me <site> - Returns active concurrent vistors from the site specified.
-    hubot chart bomb      - Returns active concurrent vistors from all sites
+    hubot chart me <site> - Returns active concurrent visitors from the site specified.
+    hubot chart bomb      - Returns active concurrent visitors from all sites

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Configuration
     #API Key
     HUBOT_CHARTBEAT_API_KEY=XXXXXXXXXXXXXXXX
 
-    #Optional Chartbeat section (Chartbeat Publishing only)
+    #Optional Chartbeat section for Chartbeat Publishing users
     HUBOT_CHARTBEAT_SECTION=example
 
 Usage

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ Configuration
     #API Key
     HUBOT_CHARTBEAT_API_KEY=XXXXXXXXXXXXXXXX
 
+    #Optional Chartbeat section (Chartbeat Publishing only)
+    HUBOT_CHARTBEAT_SECTION=example
+
 Usage
 -----
     hubot chart me        - Returns active concurrent visitors from the default site specified.
     hubot chart me <site> - Returns active concurrent vistors from the site specified.
     hubot chart bomb      - Returns active concurrent vistors from all sites
-
-

--- a/src/chartbeat.coffee
+++ b/src/chartbeat.coffee
@@ -1,18 +1,18 @@
 # Description:
-#   Display number of concurrent vistors to the specified site.
+#   Display number of concurrent visitors to the specified site or section.
 #
 # Dependencies:
 #   None
 #
 # Configuration:
 #   HUBOT_CHARTBEAT_SITE
-#   HUBOT_CHARTBEAT_SITES <comma separated string of all
+#   HUBOT_CHARTBEAT_SITES <comma separated string of all sites>
 #   HUBOT_CHARTBEAT_API_KEY <use global key for access to all sites>
-#   HUBOT_CHARTBEAT_SECTION <optional section (Chartbeat Publishing only)>
+#   HUBOT_CHARTBEAT_SECTION <optional section for Chartbeat Publishing users>
 #
 # Commands:
-#   hubot chart me - Returns active concurrent vistors from the default site specified.
-#   hubot chart me <site> - Returns active concurrent vistors from the site specified.
+#   hubot chart me - Returns active concurrent visitors from the default site specified.
+#   hubot chart me <site> - Returns active concurrent visitors from the site specified.
 #   hubot chart bomb - Returns active concurrent visitors from all sites.
 #
 # Notes:

--- a/src/chartbeat.coffee
+++ b/src/chartbeat.coffee
@@ -24,7 +24,7 @@
 #   Drew Delianides
 
 getChart = (msg, apiKey, site, section) ->
-  postUrl = "http://api.chartbeat.com/live/quickstats/v3/?apikey=#{apiKey}&host=#{site}"
+  postUrl = "http://api.chartbeat.com/live/quickstats/v4/?apikey=#{apiKey}&host=#{site}"
   if (section)
     postUrl += "&section=#{section}"
   msg.robot.http(postUrl)
@@ -34,7 +34,7 @@ getChart = (msg, apiKey, site, section) ->
          return
 
         response = JSON.parse(body)
-        people = response.people || []
+        people = response.data.stats.people || []
 
         if (people < 1)
           msg.send "It doesn't appear that #{site} has any visitors right now"

--- a/src/chartbeat.coffee
+++ b/src/chartbeat.coffee
@@ -8,6 +8,7 @@
 #   HUBOT_CHARTBEAT_SITE
 #   HUBOT_CHARTBEAT_SITES <comma separated string of all
 #   HUBOT_CHARTBEAT_API_KEY <use global key for access to all sites>
+#   HUBOT_CHARTBEAT_SECTION <optional section (Chartbeat Publishing only)>
 #
 # Commands:
 #   hubot chart me - Returns active concurrent vistors from the default site specified.
@@ -22,8 +23,11 @@
 # Author:
 #   Drew Delianides
 
-getChart = (msg, apiKey, site) ->
-  msg.robot.http("http://api.chartbeat.com/live/quickstats/v3/?apikey=#{apiKey}&host=#{site}")
+getChart = (msg, apiKey, site, section) ->
+  postUrl = "http://api.chartbeat.com/live/quickstats/v3/?apikey=#{apiKey}&host=#{site}"
+  if (section)
+    postUrl += "&section=#{section}"
+  msg.robot.http(postUrl)
       .get() (err, res, body) ->
         unless res.statusCode is 200
          msg.send "There was a problem with Chartbeat. Do you have access to this domain?"
@@ -37,7 +41,8 @@ getChart = (msg, apiKey, site) ->
           return
 
         pluralize = if (people == 1) then "person" else "people"
-        msg.send "I see #{people} #{pluralize} on #{site} right now!"
+        section = if (section) then " '#{section}' section" else ""
+        msg.send "I see #{people} #{pluralize} on #{site}#{section} right now!"
 
 module.exports = (robot) ->
   robot.respond /chart( me)? (.*)/i, (msg) ->
@@ -55,5 +60,6 @@ module.exports = (robot) ->
       else [msg.match[2]]
 
     apiKey = process.env.HUBOT_CHARTBEAT_API_KEY
+    section = process.env.HUBOT_CHARTBEAT_SECTION
 
-    getChart(msg, apiKey, site) for site in sites
+    getChart(msg, apiKey, site, section) for site in sites


### PR DESCRIPTION
For people who manage multiple websites off one domain this can be useful.

`HUBOT_CHARTBEAT_SECTION` is optional and for [Chartbeat Publishing users only](http://support.chartbeat.com/docs/api.html#quickstats).

Also updated the API URL from v3 to v4 which has a slightly different response structure.
